### PR TITLE
Fix Firestore collection binding not triggering Vue 3 reactivity

### DIFF
--- a/app/store/achievementData.js
+++ b/app/store/achievementData.js
@@ -41,7 +41,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef}) => {
-		await bindFirestoreRef('list', achievementDataRef);
+		await bindFirestoreRef('list', achievementDataRef, {wait: true});
 	}),
 };
 

--- a/app/store/achievementStatsByCategory.js
+++ b/app/store/achievementStatsByCategory.js
@@ -35,7 +35,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef}) => {
-		await bindFirestoreRef('list', achievementStatsByCategoryRef);
+		await bindFirestoreRef('list', achievementStatsByCategoryRef, {wait: true});
 	}),
 };
 

--- a/app/store/achievementStatsByDifficulty.js
+++ b/app/store/achievementStatsByDifficulty.js
@@ -35,7 +35,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef}) => {
-		await bindFirestoreRef('list', achievementStatsByDifficultyRef);
+		await bindFirestoreRef('list', achievementStatsByDifficultyRef, {wait: true});
 	}),
 };
 

--- a/app/store/achievementStatsByMonth.js
+++ b/app/store/achievementStatsByMonth.js
@@ -35,7 +35,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef}) => {
-		await bindFirestoreRef('list', achievementStatsByMonthRef);
+		await bindFirestoreRef('list', achievementStatsByMonthRef, {wait: true});
 	}),
 };
 

--- a/app/store/achievements.js
+++ b/app/store/achievements.js
@@ -67,7 +67,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef}) => {
-		await bindFirestoreRef('list', achievementsRef);
+		await bindFirestoreRef('list', achievementsRef, {wait: true});
 	}),
 	async initLatestAchievements({state, dispatch, commit}) {
 		if (!state.isInitLatestAchievemnts) {
@@ -76,7 +76,7 @@ const localActions = {
 		}
 	},
 	bindLatestAchievements: firestoreAction(async ({bindFirestoreRef}) => {
-		await bindFirestoreRef('latestAchievements', achievementsRef.orderBy('date', 'desc').limit(15));
+		await bindFirestoreRef('latestAchievements', achievementsRef.orderBy('date', 'desc').limit(15), {wait: true});
 	}),
 	bind: firestoreAction(async ({bindFirestoreRef, state, commit}, id) => {
 		if (state.isInitData[id] === process.client || state.isInitList === process.client) {

--- a/app/store/oneiromancies.js
+++ b/app/store/oneiromancies.js
@@ -33,7 +33,7 @@ const localActions = {
 		}
 	},
 	bindOneiromancyMessages: firestoreAction(async ({bindFirestoreRef, commit}) => {
-		await bindFirestoreRef('oneiromancyMessages', oneiromancyMessagesRef.orderBy('message.ts', 'desc'));
+		await bindFirestoreRef('oneiromancyMessages', oneiromancyMessagesRef.orderBy('message.ts', 'desc'), {wait: true});
 		commit('initOneiromancyMessages');
 	}),
 	async initOneiromancyCriteria({state, dispatch, commit}) {
@@ -43,7 +43,7 @@ const localActions = {
 		}
 	},
 	bindOneiromancyCriteria: firestoreAction(async ({bindFirestoreRef, commit}) => {
-		await bindFirestoreRef('oneiromancyCriteria', oneiromancyCriteriaRef.orderBy('point', 'desc'));
+		await bindFirestoreRef('oneiromancyCriteria', oneiromancyCriteriaRef.orderBy('point', 'desc'), {wait: true});
 		commit('initOneiromancyCriteria');
 	}),
 };

--- a/app/store/slowQuizGames.js
+++ b/app/store/slowQuizGames.js
@@ -35,7 +35,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef, commit}) => {
-		await bindFirestoreRef('list', slowQuizGamesRef.where('status', '==', 'finished').orderBy('finishDate', 'desc'));
+		await bindFirestoreRef('list', slowQuizGamesRef.where('status', '==', 'finished').orderBy('finishDate', 'desc'), {wait: true});
 		commit('initList');
 	}),
 };

--- a/app/store/twentyQuestionsGames.js
+++ b/app/store/twentyQuestionsGames.js
@@ -35,7 +35,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef, commit}) => {
-		await bindFirestoreRef('list', twentyQuestionsGamesRef.orderBy('finishedAt', 'desc'));
+		await bindFirestoreRef('list', twentyQuestionsGamesRef.orderBy('finishedAt', 'desc'), {wait: true});
 		commit('initList');
 	}),
 };

--- a/app/store/users.js
+++ b/app/store/users.js
@@ -45,7 +45,7 @@ const localActions = {
 		}
 	},
 	bindList: firestoreAction(async ({bindFirestoreRef, commit}) => {
-		await bindFirestoreRef('list', usersRef);
+		await bindFirestoreRef('list', usersRef, {wait: true});
 		commit('initList');
 	}),
 	bindById: firestoreAction(async ({bindFirestoreRef, state, dispatch, getters, commit}, id) => {


### PR DESCRIPTION
## Summary

- vuexfire 3.x の `VUEXFIRE_ARRAY_ADD` ミューテーションは Vue 3 の Proxy を経由せず生配列を直接 `splice` するため、Firestore からデータが届いてもコンポーネントが再レンダリングされず、`/achievements/[id]` などをリロード・直接アクセスした際に実績名などが空欄になるバグがあった
- 全コレクション binding に `{wait: true}` オプションを追加することで、ドキュメントをローカルに集めてから `VUEXFIRE_SET_VALUE` で配列全体を一括代入するようになり、Proxy の SET トラップが正しく発火して Vue 3 の reactivity が機能するようになった
- 別ページから遷移した際は `isInitList` フラグにより `bindList` がスキップされストアのキャッシュが使われるため症状が出ておらず、直接アクセス・リロード時のみ再現していた

🤖 Generated with [Claude Code](https://claude.com/claude-code)