### PR TITLE
Add tahoiya game log viewer

### DIFF
--- a/app/components/TahoiyaGame.vue
+++ b/app/components/TahoiyaGame.vue
@@ -1,0 +1,236 @@
+<template>
+	<div :id="game.id" class="TahoiyaGame box">
+		<h2 class="is-size-3 has-text-weight-bold">
+			<a :href="`#${game.id}`">
+				<span v-if="game.type === 'dictionary'"
+					>{{ game.word }}（{{ game.theme }}）</span
+				>
+				<span v-else>{{ game.theme }}</span>
+			</a>
+		</h2>
+
+		<p class="has-text-grey has-text-right is-size-6">
+			{{ formattedDate }}
+			<template v-if="game.sourceString">
+				/ 出典: {{ game.sourceString }}</template
+			>
+			<template v-if="game.author">
+				/ お題提供: {{ getUserName(game.author) }}</template
+			>
+		</p>
+
+		<div class="meanings-section mt-4">
+			<table class="table is-fullwidth meanings-table">
+				<thead>
+					<tr>
+						<th class="meaning-type-col">種別</th>
+						<th>意味</th>
+						<th class="voters-col">投票者</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						v-for="(meaning, index) in sortedMeanings"
+						:key="index"
+						:class="{'is-selected correct-row': meaning.type === 'correct'}"
+					>
+						<td>
+							<span v-if="meaning.type === 'correct'" class="tag is-success"
+								>正解</span
+							>
+							<span
+								v-else-if="meaning.type === 'user'"
+								class="meaning-user tag is-info"
+							>
+								<img
+									class="meaning-user-icon"
+									:src="getUserIcon(meaning.user ?? '')"
+									:srcset="`${getUserIcon(meaning.user ?? '')} 1x, ${getUserIcon2x(meaning.user ?? '')} 2x`"
+								>
+								{{ getUserName(meaning.user ?? '') }}
+							</span>
+							<span v-else class="tag is-light">ダミー</span>
+						</td>
+						<td class="meaning-text">{{ meaning.text }}</td>
+						<td>
+							<div class="voter-icons">
+								<img
+									v-for="voter in meaning.voters"
+									:key="voter.user"
+									class="voter-icon"
+									:src="getUserIcon(voter.user)"
+									:srcset="`${getUserIcon(voter.user)} 1x, ${getUserIcon2x(voter.user)} 2x`"
+									:title="getUserName(voter.user)"
+								>
+								<span
+									v-if="meaning.voters.length === 0"
+									class="has-text-grey-light is-size-7"
+									>なし</span
+								>
+							</div>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div
+			v-if="game.comments && game.comments.length > 0"
+			class="card comments-card mt-4"
+		>
+			<header
+				class="card-header"
+				@click="isCommentsPanelShown = !isCommentsPanelShown"
+			>
+				<p class="card-header-title">コメント ({{ game.comments.length }}件)</p>
+				<button type="button" class="card-header-icon">
+					<span class="icon">
+						<arrow-up-icon v-if="isCommentsPanelShown" />
+						<arrow-down-icon v-else />
+					</span>
+				</button>
+			</header>
+			<div v-if="isCommentsPanelShown" class="card-content">
+				<div class="content">
+					<div
+						v-for="comment in game.comments"
+						:key="comment.timestamp"
+						class="comment-item"
+					>
+						<img
+							class="comment-icon"
+							:src="getUserIcon(comment.user)"
+							:srcset="`${getUserIcon(comment.user)} 1x, ${getUserIcon2x(comment.user)} 2x`"
+						>
+						<span class="comment-user has-text-weight-semibold"
+							>{{ getUserName(comment.user) }}</span
+						>
+						<span class="comment-text">{{ comment.text }}</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import dayjs from 'dayjs';
+import {computed, ref} from 'vue';
+import ArrowDownIcon from 'vue-ionicons/dist/ios-arrow-down.vue';
+import ArrowUpIcon from 'vue-ionicons/dist/ios-arrow-up.vue';
+import {
+	getUserIcon2x as getUserIcon2xByUser,
+	getUserIcon as getUserIconByUser,
+	getUserName as getUserNameByUser,
+} from '@/lib/utils.js';
+import type {TahoiyaGame} from '@/types/store.js';
+import {useStore} from '~/plugins/vuex.js';
+
+const props = defineProps<{
+	game: TahoiyaGame;
+}>();
+
+const store = useStore();
+const isCommentsPanelShown = ref(false);
+
+const getUser = computed(() => store.getters['slackInfos/getUser']);
+
+const formattedDate = computed(() =>
+	dayjs(props.game.timestamp).format('YYYY年M月D日 HH:mm'),
+);
+
+const sortedMeanings = computed(() => {
+	const order = {correct: 0, user: 1, dummy: 2} as const;
+	return [...props.game.meanings].sort((a, b) => {
+		if (a.type !== b.type) {
+			return order[a.type] - order[b.type];
+		}
+		return b.voters.length - a.voters.length;
+	});
+});
+
+function getUserName(userId: string) {
+	return getUserNameByUser(getUser.value(userId));
+}
+
+function getUserIcon(userId: string) {
+	return getUserIconByUser(getUser.value(userId));
+}
+
+function getUserIcon2x(userId: string) {
+	return getUserIcon2xByUser(getUser.value(userId));
+}
+</script>
+
+<style scoped>
+.TahoiyaGame .meanings-table {
+	table-layout: fixed;
+}
+
+.TahoiyaGame .meaning-type-col {
+	width: 20%;
+}
+
+.TahoiyaGame .voters-col {
+	width: 20%;
+}
+
+.TahoiyaGame .meaning-text {
+	word-break: break-all;
+}
+
+.TahoiyaGame .correct-row {
+	background-color: #effaf5;
+}
+
+.TahoiyaGame .meaning-user {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	height: auto;
+	white-space: normal;
+}
+
+.TahoiyaGame .meaning-user-icon {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.TahoiyaGame .voter-icons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.25rem;
+	align-items: center;
+}
+
+.TahoiyaGame .voter-icon {
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+}
+
+.TahoiyaGame .comments-card .card-header {
+	cursor: pointer;
+}
+
+.TahoiyaGame .comment-item {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+
+.TahoiyaGame .comment-icon {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	vertical-align: middle;
+	flex-shrink: 0;
+}
+
+.TahoiyaGame .comment-text {
+	word-break: break-all;
+}
+</style>

--- a/app/components/TahoiyaGame.vue
+++ b/app/components/TahoiyaGame.vue
@@ -38,10 +38,7 @@
 							<span v-if="meaning.type === 'correct'" class="tag is-success"
 								>正解</span
 							>
-							<span
-								v-else-if="meaning.type === 'user'"
-								class="meaning-user tag is-info"
-							>
+							<span v-else-if="meaning.type === 'user'" class="meaning-user">
 								<img
 									class="meaning-user-icon"
 									:src="getUserIcon(meaning.user ?? '')"
@@ -49,7 +46,7 @@
 								>
 								{{ getUserName(meaning.user ?? '') }}
 							</span>
-							<span v-else class="tag is-light">ダミー</span>
+							<span v-else class="has-text-grey">ダミー</span>
 						</td>
 						<td class="meaning-text">{{ meaning.text }}</td>
 						<td>
@@ -187,8 +184,6 @@ function getUserIcon2x(userId: string) {
 	display: inline-flex;
 	align-items: center;
 	gap: 0.25rem;
-	height: auto;
-	white-space: normal;
 }
 
 .TahoiyaGame .meaning-user-icon {

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -32,6 +32,9 @@
 							<nuxt-link class="navbar-item" to="/records/twenty-questions">
 								20の扉
 							</nuxt-link>
+							<nuxt-link class="navbar-item" to="/records/tahoiya">
+								たほいや
+							</nuxt-link>
 							<nuxt-link class="navbar-item" to="/records/topic">
 								トピック
 							</nuxt-link>

--- a/app/pages/records/tahoiya.vue
+++ b/app/pages/records/tahoiya.vue
@@ -5,7 +5,70 @@
 
 		<p class="title">たほいやログ</p>
 
-		<tahoiya-game v-for="game in games" :key="game.id" :game="game" />
+		<nav v-if="totalPages > 1" class="pagination mb-4" aria-label="pagination">
+			<a
+				class="pagination-previous"
+				:class="{'is-disabled': currentPage === 1}"
+				@click="currentPage = Math.max(1, currentPage - 1)"
+			>
+				前のページ
+			</a>
+			<a
+				class="pagination-next"
+				:class="{'is-disabled': currentPage === totalPages}"
+				@click="currentPage = Math.min(totalPages, currentPage + 1)"
+			>
+				次のページ
+			</a>
+			<ul class="pagination-list">
+				<li v-if="currentPage >= 3">
+					<a class="pagination-link" @click="currentPage = 1">1</a>
+				</li>
+				<li v-if="currentPage >= 4">
+					<span class="pagination-ellipsis">&hellip;</span>
+				</li>
+				<li v-if="currentPage >= 2">
+					<a class="pagination-link" @click="currentPage = currentPage - 1"
+						>{{ currentPage - 1 }}</a
+					>
+				</li>
+				<li>
+					<a class="pagination-link is-current">{{ currentPage }}</a>
+				</li>
+				<li v-if="currentPage <= totalPages - 1">
+					<a class="pagination-link" @click="currentPage = currentPage + 1"
+						>{{ currentPage + 1 }}</a
+					>
+				</li>
+				<li v-if="currentPage <= totalPages - 3">
+					<span class="pagination-ellipsis">&hellip;</span>
+				</li>
+				<li v-if="currentPage <= totalPages - 2">
+					<a class="pagination-link" @click="currentPage = totalPages"
+						>{{ totalPages }}</a
+					>
+				</li>
+			</ul>
+		</nav>
+
+		<tahoiya-game v-for="game in pagedGames" :key="game.id" :game="game" />
+
+		<nav v-if="totalPages > 1" class="pagination mt-4" aria-label="pagination">
+			<a
+				class="pagination-previous"
+				:class="{'is-disabled': currentPage === 1}"
+				@click="currentPage = Math.max(1, currentPage - 1)"
+			>
+				前のページ
+			</a>
+			<a
+				class="pagination-next"
+				:class="{'is-disabled': currentPage === totalPages}"
+				@click="currentPage = Math.min(totalPages, currentPage + 1)"
+			>
+				次のページ
+			</a>
+		</nav>
 	</div>
 </template>
 
@@ -17,8 +80,17 @@ useHead({title: 'たほいやログ - achievement-viewer'});
 
 const store = useStore();
 const isLoading = ref(true);
+const currentPage = ref(1);
+const GAMES_PER_PAGE = 20;
 
 const games = computed(() => store.state.tahoiyaGames.list);
+const totalPages = computed(() =>
+	Math.ceil(games.value.length / GAMES_PER_PAGE),
+);
+const pagedGames = computed(() => {
+	const start = (currentPage.value - 1) * GAMES_PER_PAGE;
+	return games.value.slice(start, start + GAMES_PER_PAGE);
+});
 
 onMounted(async () => {
 	await Promise.all([

--- a/app/pages/records/tahoiya.vue
+++ b/app/pages/records/tahoiya.vue
@@ -1,0 +1,30 @@
+<template>
+	<div class="container is-max-desktop">
+		<progress v-if="isLoading" class="progress is-small is-primary" max="100" />
+		<unauthorized-notification />
+
+		<p class="title">たほいやログ</p>
+
+		<tahoiya-game v-for="game in games" :key="game.id" :game="game" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import {computed, onMounted, ref} from 'vue';
+import {useStore} from '~/plugins/vuex.js';
+
+useHead({title: 'たほいやログ - achievement-viewer'});
+
+const store = useStore();
+const isLoading = ref(true);
+
+const games = computed(() => store.state.tahoiyaGames.list);
+
+onMounted(async () => {
+	await Promise.all([
+		store.dispatch('tahoiyaGames/initList'),
+		store.dispatch('slackInfos/initUsers'),
+	]);
+	isLoading.value = false;
+});
+</script>

--- a/app/plugins/vuex.ts
+++ b/app/plugins/vuex.ts
@@ -17,6 +17,8 @@ import type {SlackInfosState} from '~/store/slackInfos.js';
 import * as slackInfos from '~/store/slackInfos.js';
 import type {SlowQuizGamesState} from '~/store/slowQuizGames.js';
 import * as slowQuizGames from '~/store/slowQuizGames.js';
+import type {TahoiyaGamesState} from '~/store/tahoiyaGames.js';
+import * as tahoiyaGames from '~/store/tahoiyaGames.js';
 import type {TwentyQuestionsGamesState} from '~/store/twentyQuestionsGames.js';
 import * as twentyQuestionsGames from '~/store/twentyQuestionsGames.js';
 import type {UsersState} from '~/store/users.js';
@@ -31,6 +33,7 @@ export interface RootState {
 	achievementStatsByMonth: AchievementStatsByMonthState;
 	slowQuizGames: SlowQuizGamesState;
 	twentyQuestionsGames: TwentyQuestionsGamesState;
+	tahoiyaGames: TahoiyaGamesState;
 	users: UsersState;
 	oneiromancies: OneiromanciesState;
 	slackInfos: SlackInfosState;
@@ -72,6 +75,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 			achievementStatsByMonth: {namespaced: true, ...achievementStatsByMonth},
 			slowQuizGames: {namespaced: true, ...slowQuizGames},
 			twentyQuestionsGames: {namespaced: true, ...twentyQuestionsGames},
+			tahoiyaGames: {namespaced: true, ...tahoiyaGames},
 			users: {namespaced: true, ...users},
 			oneiromancies: {namespaced: true, ...oneiromancies},
 			slackInfos: {namespaced: true, ...slackInfos},

--- a/app/store/tahoiyaGames.ts
+++ b/app/store/tahoiyaGames.ts
@@ -1,0 +1,78 @@
+import {
+	collection,
+	onSnapshot,
+	orderBy,
+	query,
+	type Unsubscribe,
+} from 'firebase/firestore';
+import db from '~/lib/db.js';
+import type {TahoiyaGame} from '~/types/store.js';
+
+const tahoiyaGamesRef = collection(db, 'tahoiya_games');
+let unsubscribeList: Unsubscribe | null = null;
+
+export interface TahoiyaGamesState {
+	isInitList: boolean | null;
+	list: TahoiyaGame[];
+}
+
+const localState = (): TahoiyaGamesState => ({
+	isInitList: null,
+	list: [],
+});
+
+const localMutations = {
+	setList(state: TahoiyaGamesState, list: TahoiyaGame[]) {
+		state.list = list;
+		state.isInitList = import.meta.client;
+	},
+};
+
+const localGetters = {
+	list: (state: TahoiyaGamesState) => state.list,
+};
+
+const localActions = {
+	async initList({
+		state,
+		commit,
+	}: {
+		state: TahoiyaGamesState;
+		commit: Function;
+	}) {
+		if (state.isInitList) return;
+		await new Promise<void>((resolve, reject) => {
+			unsubscribeList?.();
+			let resolved = false;
+			unsubscribeList = onSnapshot(
+				query(tahoiyaGamesRef, orderBy('timestamp', 'desc')),
+				(snapshot) => {
+					commit(
+						'setList',
+						snapshot.docs.map((d) => ({
+							...(d.data() as TahoiyaGame),
+							id: d.id,
+						})),
+					);
+					if (!resolved) {
+						resolved = true;
+						resolve();
+					}
+				},
+				(error) => {
+					if (!resolved) {
+						resolved = true;
+						reject(error);
+					}
+				},
+			);
+		});
+	},
+};
+
+export {
+	localActions as actions,
+	localGetters as getters,
+	localMutations as mutations,
+	localState as state,
+};

--- a/app/types/store.ts
+++ b/app/types/store.ts
@@ -101,3 +101,31 @@ export interface TwentyQuestionsGame {
 	finishedAt: {toDate(): Date};
 	players: TwentyQuestionsPlayer[];
 }
+
+export interface TahoiyaGameMeaning {
+	text: string;
+	type: 'correct' | 'user' | 'dummy';
+	user?: string;
+	source?: string;
+	voters: {user: string}[];
+}
+
+export interface TahoiyaGameComment {
+	user: string;
+	text: string;
+	timestamp: number;
+}
+
+export interface TahoiyaGame {
+	id: string;
+	timestamp: number;
+	theme: string;
+	word: string;
+	type: 'dictionary' | 'arbitrary';
+	sourceString: string;
+	url: string;
+	meanings: TahoiyaGameMeaning[];
+	comments: TahoiyaGameComment[];
+	author: string | null;
+	participants: string[];
+}


### PR DESCRIPTION
## Summary

- `tahoiya_games` Firestoreコレクションからデータを読み込む Vuex ストアモジュール (`tahoiyaGames`) を追加
- ゲーム1件を表示する `TahoiyaGame` コンポーネントを追加（意味一覧テーブル：正解/参加者/ダミーのバッジ表示・投票者アイコン表示、コメント折り畳みパネル）
- `/records/tahoiya` ページを追加
- ナビバー「各種ログ」ドロップダウンに「たほいや」リンクを追加
- `TahoiyaGame` / `TahoiyaGameMeaning` / `TahoiyaGameComment` 型定義を追加

## Test plan

- [ ] `/records/tahoiya` にアクセスしてゲームログが一覧表示される
- [ ] 辞書型ゲームで `word（theme）` 形式のタイトルが表示される
- [ ] arbitrary型ゲームで `theme` のみのタイトルが表示される
- [ ] 正解行が緑色でハイライトされる
- [ ] ユーザーの意味にアイコンと名前が表示される
- [ ] 投票者アイコンが正しく表示される
- [ ] コメントがある場合、折り畳みパネルで確認できる
- [ ] ナビバーの「各種ログ」に「たほいや」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)